### PR TITLE
fix: Generator no longer runs out of memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+data/*.p
+**/__pycache__

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ For consistency, we provide a ready-to-use Docker image in this repo. To downloa
 Build the Docker image by:
 
 ```
-chmod a+x docker-build && ./docker-build
+chmod a+x build-docker && ./build-docker
 ```
 
 OR
 
 ```
-sh docker-build
+sh build-docker
 ```
 
 This command builds the image, and start up a bash environment that we can train and test within. It includes the libraries necessary for running all forms of pretraining (Wikipedia inlcuded). Use the following command after you exit the container and wish to start it again.
@@ -38,7 +38,7 @@ This command builds the image, and start up a bash environment that we can train
 ./run
 ```
 
-The script above is set to mount the working directory and uses GPU0 on your system. Please alter the script to utilize more GPUs if you want to speed up the training process (i.e., -e NVIDIA*VISIBLE_DEVICES=0,1* to use 2 GPUs, on newer versions of CUDA, you will need the --gpus flag. Edit the run script as necessary.).
+The script above is set to mount the working directory and uses GPU0 on your system. Please alter the script to utilize more GPUs if you want to speed up the training process (i.e., `-e NVIDIA*VISIBLE_DEVICES=0,1*` to use 2 GPUs, on newer versions of CUDA, you will need the `--gpus` flag. Edit the run script as necessary.).
 
 #### Step 2
 

--- a/data/util/generation/generator.py
+++ b/data/util/generation/generator.py
@@ -68,17 +68,23 @@ def generate(number, template="random", out_path="../../gen.p", complex_problems
             path_list = [ADDITION, SUBTRACTION, DIVISION, MULTIPLICATION]
 
     opl = path_list
-    name_list = []
-    location_list = []
-    object_list = []
-    word_number_list = []
+    with open(NAMES, 'r') as fh:
+        name_list = fh.readlines()
+    with open(LOCATIONS, 'r') as fh:
+        location_list = fh.readlines()
+    with open(OBJECTS, 'r') as fh:
+        object_list = fh.readlines()
+    with open(WORD_NUMBERS, 'r') as fh:
+        word_number_list = fh.readlines()
     word_operations = ["plus", "minus", "divide", "multiply"]
 
-    with open(WORD_NUMBERS, 'r') as fh:
-        lines = fh.readlines()
-
-        for line in lines:
-            word_number_list.append(line)
+    path_contents_list = []
+    for path in path_list:
+        with open(path, 'r') as fh:
+            path_contents_list.append([])
+            for line in fh.readlines():
+                sp = line.split(', ')
+                path_contents_list[-1].append((sp[0], sp[1]))
 
     progress_new = 0
     for i in range(number):
@@ -86,49 +92,13 @@ def generate(number, template="random", out_path="../../gen.p", complex_problems
         if not i == progress_new or i == 0:
             print(f"Progress: %d%%\r" % progress_new, end="")
 
-        template_list = []
-
         # Determine the type of problem if randomly selected
         problem_type_split = int((number / len(opl)))
         if template == "random":
             if i % problem_type_split == 0 and not i < problem_type_split:
-                path_list = path_list[1:]
+                path_contents_list = path_contents_list[1:]
 
-        path = path_list[0]
-
-        with open(NAMES, 'r') as fh:
-            lines = fh.readlines()
-
-            for line in lines:
-                name_list.append(line)
-
-        with open(LOCATIONS, 'r') as fh:
-            lines = fh.readlines()
-
-            for line in lines:
-                location_list.append(line)
-
-        with open(OBJECTS, 'r') as fh:
-            lines = fh.readlines()
-
-            for line in lines:
-                object_list.append(line)
-
-        with open(path, 'r') as fh:
-            lines = fh.readlines()
-
-            if template == "random":
-                index = random.randint(0, len(lines) - 1)
-                sp = lines[index].split(', ')
-                template_list.append((sp[0], sp[1]))
-            else:
-                for line in lines:
-                    sp = line.split(', ')
-                    template_list.append((sp[0], sp[1]))
-
-        te = template_list[random.randint(0, len(template_list) - 1)]
-        question = list(te)[0]
-        equation = list(te)[1]
+        question, equation = random.choice(path_contents_list[0])
 
         if not WORD_PROBLEMS:
             num1 = get_random(0, 100000)
@@ -211,7 +181,7 @@ def generate(number, template="random", out_path="../../gen.p", complex_problems
         question = re.sub("LOC2", location2, question)
 
         if WORD_PROBLEMS:
-            # Need to replace operators befor the numbers are inserted
+            # Need to replace operators before the numbers are inserted
             # This avoids replacing hyphenated number words
             def pad(what):
                 return " " + what + " "


### PR DESCRIPTION
The problem generator was re-reading the input files on every iteration of the loop and appending their data to a list that was not cleared between iterations. This led to the script crashing as it ran out of memory on my system.

Since the input files shouldn't change while generating, and it resulted in a significant speedup, I moved the reads out of the loop. The generator script finishes in ~30 seconds on my machine now. This still feels really slow to me, 50000 isn't a very big number, but it works!

Also corrects the docker setup instructions in the readme and adds a gitignore to avoid accidentally including the generated data.